### PR TITLE
Remove unused CCR1 field

### DIFF
--- a/Project Documentation/nxps32k358_lpspi.md
+++ b/Project Documentation/nxps32k358_lpspi.md
@@ -52,7 +52,6 @@ The NXP S32K358 LPSPI (Low Power Serial Peripheral Interface) is a QEMU device m
         -   `uint32_t lpspi_cfgr0`: Configuration Register 0.
         -   `uint32_t lpspi_cfgr1`: Configuration Register 1.
         -   `uint32_t lpspi_ccr`: Clock Configuration Register.
-        -   `uint32_t lpspi_ccr1`: Reserved for future use.
         -   `uint32_t lpspi_fcr`: FIFO Control Register.
         -   `uint32_t lpspi_fsr`: FIFO Status Register.
         -   `uint32_t lpspi_tcr`: Transmit Command Register.

--- a/qemu/include/hw/ssi/nxps32k358_lpspi.h
+++ b/qemu/include/hw/ssi/nxps32k358_lpspi.h
@@ -72,8 +72,6 @@ struct NXPS32K358LPSPIState
     uint32_t lpspi_cfgr0;
     uint32_t lpspi_cfgr1;
     uint32_t lpspi_ccr;
-    uint32_t lpspi_ccr1;
-
     uint32_t lpspi_fcr;
     uint32_t lpspi_fsr;
     uint32_t lpspi_tcr;


### PR DESCRIPTION
## Summary
- delete the unused lpspi_ccr1 field from NXPS32K358LPSPIState
- update documentation accordingly

## Testing
- `make -C qemu -n all` *(fails: Please call configure before running make)*
- `./configure --help`

------
https://chatgpt.com/codex/tasks/task_e_685c56d8e6148331bc98603f5cc0556f