### PR TITLE
Enable 4 CS lines for nxps32k358 LPSPI

### DIFF
--- a/qemu/hw/arm/nxps32k358_soc.c
+++ b/qemu/hw/arm/nxps32k358_soc.c
@@ -418,6 +418,7 @@ static void nxps32k358_soc_realize(DeviceState *dev_soc, Error **errp)
     for (i = 0; i < NXP_NUM_LPSPIS; i++)
     {
         dev = DEVICE(&(s->lpspis[i]));
+        qdev_prop_set_uint8(dev, "num-cs-lines", 4);
         if (!sysbus_realize(SYS_BUS_DEVICE(&s->lpspis[i]), errp))
         {
             return;

--- a/qemu/hw/ssi/nxps32k358_lpspi.c
+++ b/qemu/hw/ssi/nxps32k358_lpspi.c
@@ -366,7 +366,7 @@ static const VMStateDescription vmstate_nxps32k358_lpspi = {
         VMSTATE_END_OF_LIST()}};
 
 static const Property nxps32k358_lpspi_properties[] = {
-    DEFINE_PROP_UINT8("num-cs-lines", NXPS32K358LPSPIState, num_cs_lines, 1),
+    DEFINE_PROP_UINT8("num-cs-lines", NXPS32K358LPSPIState, num_cs_lines, 4),
 };
 
 static void nxps32k358_lpspi_realize(DeviceState *dev, Error **errp)


### PR DESCRIPTION
## Summary
- default nxps32k358 LPSPI CS lines to 4
- set the property from the SoC realisation so boards get 4 CS lines

## Testing
- `./configure --target-list=arm-softmmu --enable-debug` *(fails: Dependency "glib-2.0" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5b71b7d88331899e42fab5436838