### PR TITLE
Mask TX/RX counts before updating FSR

### DIFF
--- a/Project Documentation/nxps32k358_lpspi.md
+++ b/Project Documentation/nxps32k358_lpspi.md
@@ -81,13 +81,14 @@ The driver uses a macro `DB_PRINT_L` to conditionally emit debug logs. This macr
 
             -   **TX Word Count**: Computed by dividing the number of bytes used in the TX FIFO by 4.
             -   **RX Word Count**: Computed by dividing the number of bytes used in the RX FIFO by 4.
+            -   Both counts are masked with `0xF` to fit the 4-bit fields in `FSR`.
 
     -   **FIFO Status Register (`FSR`) Update**:
 
-        -   Encodes the word counts into the `FSR` register:
+        -   Encodes the word counts into the `FSR` register after masking:
 
-            -   Lower 16 bits: TX Word Count.
-            -   Upper 16 bits: RX Word Count.
+            -   Lower 16 bits: TX Word Count (masked with `0xF`).
+            -   Upper 16 bits: RX Word Count (masked with `0xF`).
 
     -   **Status Register (`SR`) Update**:
 

--- a/qemu/hw/ssi/nxps32k358_lpspi.c
+++ b/qemu/hw/ssi/nxps32k358_lpspi.c
@@ -35,8 +35,8 @@
  */
 static void lpspi_update_status(NXPS32K358LPSPIState *s)
 {
-    uint8_t tx_word_count = fifo8_num_used(&s->tx_fifo) / 4;
-    uint8_t rx_word_count = fifo8_num_used(&s->rx_fifo) / 4;
+    uint8_t tx_word_count = (fifo8_num_used(&s->tx_fifo) / 4) & 0xF;
+    uint8_t rx_word_count = (fifo8_num_used(&s->rx_fifo) / 4) & 0xF;
 
     s->lpspi_fsr = (rx_word_count << 16) | (tx_word_count << 0);
 


### PR DESCRIPTION
## Summary
- mask FIFO word counts with `0xF` in `lpspi_update_status`
- document the masking behavior in `nxps32k358_lpspi.md`

## Testing
- `./configure --target-list=arm-softmmu --disable-werror` *(fails: Dependency "glib-2.0" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5db6e6dc8331a0e586250387debd