### PR TITLE
Implement continuous chip select for LPSPI

### DIFF
--- a/qemu/hw/ssi/nxps32k358_lpspi.c
+++ b/qemu/hw/ssi/nxps32k358_lpspi.c
@@ -134,8 +134,15 @@ static void lpspi_flush_txfifo(NXPS32K358LPSPIState *s)
         fifo8_push(&s->rx_fifo, (rx_word >> 24) & 0xFF);
     }
 
-    DB_PRINT("De-asserting CS%d after transfer burst.\n", pcs);
-    qemu_set_irq(s->cs_lines[pcs], 1);
+    if ((s->lpspi_tcr & TCR_CONT) && fifo8_num_used(&s->tx_fifo) >= 4)
+    {
+        DB_PRINT("Keeping CS%d asserted for continuous transfer.\n", pcs);
+    }
+    else
+    {
+        DB_PRINT("De-asserting CS%d after transfer burst.\n", pcs);
+        qemu_set_irq(s->cs_lines[pcs], 1);
+    }
 
     if (fifo8_is_empty(&s->tx_fifo))
     {

--- a/qemu/include/hw/ssi/nxps32k358_lpspi.h
+++ b/qemu/include/hw/ssi/nxps32k358_lpspi.h
@@ -43,6 +43,8 @@ OBJECT_DECLARE_SIMPLE_TYPE(NXPS32K358LPSPIState, NXPS32K358_LPSPI)
 // Transmit Command Register (TCR) bits and masks
 #define TCR_PCS_SHIFT 24
 #define TCR_PCS_MASK (0x3 << TCR_PCS_SHIFT)
+/* Continuous transfer bit in the Transmit Command Register */
+#define TCR_CONT (1U << 23)
 
 // FIFO depth and capacity definitions
 #define LPSPI_FIFO_WORD_DEPTH 4


### PR DESCRIPTION
## Summary
- add `TCR_CONT` flag to the LPSPI header
- keep chip select asserted if `CONT` is set and data remains

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685c5dbbde6483318c0602d8277b4bce